### PR TITLE
Main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,38 +15,7 @@ on:
         required: true
 
 jobs:
-  build-amd64:
-    runs-on: ubuntu-24.04
-    steps:      
-      - name: Checkout 
-        uses: actions/checkout@v4
-
-      - name: Login to Docker.io
-        uses: docker/login-action@v3
-        with:
-          username: ${{ inputs.username }}
-          password: ${{ inputs.password }}
-
-      - name: Docker Metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          tags: latest
-          images: ${{ inputs.username }}/${{ inputs.image_name }}
-
-      - name: Build and Push for AMD64
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          no-cache: true
-          provenance: false
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-
-
-  build-arm64:
+  build:
     runs-on: ubuntu-24.04
     steps:      
       - name: Checkout 
@@ -71,13 +40,13 @@ jobs:
           tags: latest
           images: ${{ inputs.username }}/${{ inputs.image_name }}
 
-      - name: Build and Push for ARM64
+      - name: Build and Push for ARM64 and AMD64
         uses: docker/build-push-action@v5
         with:
           push: true
           no-cache: true
           provenance: false
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Docker.io
+name: Push to docker.io
 
 on:
   workflow_dispatch:
@@ -15,13 +15,43 @@ on:
         required: true
 
 jobs:
-  build:
+  build-amd64:
     runs-on: ubuntu-24.04
-
-    steps:
+    steps:      
       - name: Checkout 
         uses: actions/checkout@v4
 
+      - name: Login to Docker.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.username }}
+          password: ${{ inputs.password }}
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: latest
+          images: ${{ inputs.username }}/${{ inputs.image_name }}
+
+      - name: Build and Push for AMD64
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          no-cache: true
+          provenance: false
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+
+
+  build-arm64:
+    runs-on: ubuntu-24.04
+    steps:      
+      - name: Checkout 
+        uses: actions/checkout@v4
+      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -38,18 +68,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          tags: |
-            latest
-          images: |
-            ${{ inputs.username }}/${{ inputs.image_name }}
+          tags: latest
+          images: ${{ inputs.username }}/${{ inputs.image_name }}
 
-      - name: Build and Push to Docker.io
+      - name: Build and Push for ARM64
         uses: docker/build-push-action@v5
         with:
           push: true
           no-cache: true
           provenance: false
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    steps:      
-      - name: Checkout 
+    steps:
+      - name: Checkout
         uses: actions/checkout@v4
       
       - name: Set up QEMU
@@ -28,10 +28,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker.io
-        uses: docker/login-action@v3
-        with:
-          username: ${{ inputs.username }}
-          password: ${{ inputs.password }}
+        env:
+          DOCKER_USERNAME: ${{ inputs.username }}
+          DOCKER_PASSWORD: ${{ inputs.password }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
       - name: Docker Metadata
         id: meta

--- a/Aeon
+++ b/Aeon
@@ -13,7 +13,7 @@ apt-get install -y python3.12 python3.12-dev python3.12-venv python3-pip libpyth
 apt-get install -y --no-install-recommends \
     apt-utils aria2 curl zstd git libmagic-dev \
     locales mediainfo neofetch p7zip-full \
-    p7zip-rar tzdata wget qbittorrent-nox \
+    p7zip-rar tzdata wget \
     autoconf automake build-essential cmake \
     g++ gcc gettext gpg-agent intltool libtool \
     make unzip zip autoconf automake libtool \
@@ -22,13 +22,35 @@ apt-get install -y --no-install-recommends \
     libfreeimage-dev swig libboost-all-dev \
     libpthread-stubs0-dev zlib1g-dev
 
+# Detect system architecture
+ARCH=$(uname -m)
+
+# Download and install qbittorrent-nox
+mkdir -p /usr/local/bin
+if [ "$ARCH" = "x86_64" ]; then
+    wget -qO /usr/local/bin/xnox https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/x86_64-qbittorrent-nox
+elif [ "$ARCH" = "aarch64" ]; then
+    wget -qO /usr/local/bin/xnox https://github.com/userdocs/qbittorrent-nox-static/releases/latest/download/aarch64-qbittorrent-nox
+else
+    echo "Unsupported architecture for qbittorrent-nox: $ARCH"
+    exit 1
+fi
+chmod 700 /usr/local/bin/xnox
+
 # Create temporary directory and install FFmpeg
 mkdir /Temp
 cd /Temp
-wget https://github.com/arakurumi/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-nonfree-7.1.tar.xz
-7z x ffmpeg-n7.1-latest-linux64-nonfree-7.1.tar.xz
-7z x ffmpeg-n7.1-latest-linux64-nonfree-7.1.tar
-cd /Temp/ffmpeg-n7.1-latest-linux64-nonfree-7.1/bin
+if [ "$ARCH" = "x86_64" ]; then
+    wget https://github.com/5hojib/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-nonfree-7.1.tar.xz
+elif [ "$ARCH" = "aarch64" ]; then
+    wget https://github.com/5hojib/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linuxarm64-nonfree-7.1.tar.xz
+else
+    echo "Unsupported architecture for FFmpeg: $ARCH"
+    exit 1
+fi
+7z x ffmpeg-n7.1-latest-linux*-nonfree-7.1.tar.xz
+7z x ffmpeg-n7.1-latest-linux*-nonfree-7.1.tar
+cd /Temp/ffmpeg-n7.1-latest-linux*/bin
 mv ffmpeg /usr/bin/xtra
 mv ffprobe /usr/bin/ffprobe
 mv ffplay /usr/bin/ffplay
@@ -37,11 +59,10 @@ chmod +x /usr/bin/xtra /usr/bin/ffprobe /usr/bin/ffplay
 # Install rclone and rename binaries
 cd /Temp
 curl https://rclone.org/install.sh | bash
-
-# rename binaries
 mv /usr/bin/rclone /usr/bin/xone
 mv /usr/bin/aria2c /usr/bin/xria
-mv /usr/bin/qbittorrent-nox /usr/bin/xnox
+
+pip3 install --break-system-packages --no-cache-dir -U setuptools uv
 
 # Clone and build MEGA SDK
 git clone https://github.com/meganz/sdk.git --depth=1 -b v4.8.0 /home/sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.10
 ENV DEBIAN_FRONTEND=noninteractive
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This repository provides a GitHub Actions workflow to build and push Docker imag
 
 ## Inputs
 
-| Input        | Description                        | Required |
-|--------------|------------------------------------|----------|
-| `username`   | Your Docker Hub username           | ✅       |
-| `password`   | Your Docker Hub password           | ✅       |
-| `image_name` | Name of the Docker image to build  | ✅       |
+| Input        | Description                        |
+|--------------|------------------------------------|
+| `username`   | Your Docker Hub username           |
+| `password`   | Your Docker Hub password           |
+| `image_name` | Name of the Docker image to build  |
 
 ## Notes
 
@@ -31,4 +31,4 @@ This repository provides a GitHub Actions workflow to build and push Docker imag
 
 ## Support
 
-For issues, open an issue in this repository.
+For issues, join here https://t.me/AeonDiscussion.


### PR DESCRIPTION
## Summary by Sourcery

Update the Docker build workflow to push to Docker Hub.

Enhancements:
- Update the base image from `ubuntu:24.04` to `ubuntu:24.10`.

CI:
- Rename the workflow from "Docker.io" to "Push to docker.io".
- Update the Docker login step to use environment variables for credentials.
- Update the Docker build and push step to build and push for both ARM64 and AMD64 architectures.
- Update the Docker metadata action to simplify tags and images.
- Remove required status from inputs in README.